### PR TITLE
Add cli feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,18 @@ license = "CC0-1.0"
 [dependencies]
 atty = "0.2.14"
 base64 = "0.13.0"
-clap = "2.33.3"
+clap = { version = "2.33.3", optional = true } 
 encoding_rs = "0.8.29"
 percent-encoding = "2.1.0"
 url = "2.2.2"
 
 [dev-dependencies]
 assert_cmd = "2.0.2"
+
+[features]
+default = ["cli"]
+cli = ["clap"]
+
+[[bin]]
+name = "dataurl"
+required-features = ["cli"]


### PR DESCRIPTION
# Description of change
Adds a `cli` feature. Allows users to choose whether they want to import the `CLI` fucntionality. 

Additionally, the version of the `clap` library, which is used by the `CLI`, depends on `ansi_term`, which is [unmaintained](https://github.com/iotaledger/identity.rs/issues/978). 

## Type of change
- [x] Enhancement (a non-breaking change which adds functionality)